### PR TITLE
Call instance.resetUndo(); on load so undo doesn't clear everythng

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -96,6 +96,10 @@
                             if (setPristine !== true || data !== ngModel.$viewValue) {
                                 ngModel.$setViewValue(data);
                             }
+                            
+                            if (setPristine === true) {
+                                instance.resetUndo();
+                            }
 
                             if (setPristine === true && form) {
                                 form.$setPristine();


### PR DESCRIPTION
Noticed an issue where you open ckeditor with data and are able to ctrl+Z and remove all existing data from the editor.
